### PR TITLE
Make "secondary-selection" face inherit "hl-line".

### DIFF
--- a/distinguished-theme.el
+++ b/distinguished-theme.el
@@ -71,6 +71,7 @@
    `(hl-line ((t (:background ,dst-bg+0))))
    `(minibuffer-prompt ((t (:foreground ,dst-green :weight bold))))
    `(region ((t (:background ,dst-bg+2))))
+   `(secondary-selection ((t (:inherit hl-line))))
    `(fringe ((t (:foreground ,dst-gray :background ,dst-bg+0))))
    `(vertical-border ((t (:foreground ,dst-bg+2))))
    `(mode-line ((t (:foreground ,dst-gray+2 :background ,dst-bg+2 :box (:line-width -1 :style released-button)))))


### PR DESCRIPTION
Looks like secondary selection is rarely used, but its style is inherited by a few other faces (magit actively uses it in its magit-status output). I though it would be appropriate to make it equal to hl-line.
