### PR TITLE
Set comment font to be italic.

### DIFF
--- a/distinguished-theme.el
+++ b/distinguished-theme.el
@@ -80,7 +80,7 @@
 
    ;; font lock
    `(font-lock-builtin-face ((t (:foreground ,dst-yellow+1 :weight bold))))
-   `(font-lock-comment-face ((t (:foreground ,dst-gray))))
+   `(font-lock-comment-face ((t (:foreground ,dst-gray, :slant italic))))
    `(font-lock-comment-delimiter-face ((t (:foreground ,dst-bg+2))))
    `(font-lock-doc-face ((t (:foreground ,dst-gray))))
    `(font-lock-constant-face ((t (:foreground ,dst-yellow+1 :weight bold))))


### PR DESCRIPTION
Set the comment font to be italic will make the difference between codes and comments more obvious.
